### PR TITLE
Raise error from `jdk.install`

### DIFF
--- a/jdk/__init__.py
+++ b/jdk/__init__.py
@@ -168,8 +168,9 @@ def install(
         jdk_file = _download(url)
         jdk_ext = _get_normalized_compressed_file_ext(jdk_file)
         jdk_dir = _decompress_archive(jdk_file, jdk_ext, path)
-
         return jdk_dir
+    except BaseException as e:
+        raise e
     finally:
         if jdk_file:
             os.remove(jdk_file)


### PR DESCRIPTION
If `install` raises an error, this gets masked by the `finally` block and `None` is returned Reraise the error after the finally block so it can be handled